### PR TITLE
Eliminating the need to have jQuery for this plugin to work

### DIFF
--- a/orbicular/orbicular.js
+++ b/orbicular/orbicular.js
@@ -51,7 +51,7 @@
 
                         // Width must be an even number of pixels for the effect to work.
                         setWidth = function () {
-                            var width = element.width();
+                            var width = element.prop('offsetWidth');
                             element.css('font-size', width - (width % 2) + 'px');
                         },
 


### PR DESCRIPTION
Just a simple switch of the usage of `element.width()` for `element.prop('offsetWidth')` so that jQuery is not required.

Some users of Angular prefer not to load jQuery and want to use the default jQlite that comes with Angular - this will accommodate both sets of users by using .prop() in place of the unsupported-by-jqlite width(). All tests still pass.

Thanks!
