### PR TITLE
Renamed progress attribute to progression to prevent conflict with UI Bootstrap

### DIFF
--- a/orbicular/orbicular.js
+++ b/orbicular/orbicular.js
@@ -36,7 +36,7 @@
                 replace: true,
                 restrict: 'EA',
                 scope: {
-                    current: '=progress',
+                    current: '=progression',
                     total: '='
                 },
                 link: function (scope, element) {

--- a/test/spec/orbicularSpec.js
+++ b/test/spec/orbicularSpec.js
@@ -14,10 +14,10 @@ describe('Orbicular:orbicular (directive)', function() {
         module('Orbicular');
 
         inject(function($rootScope, $compile) {
-            $rootScope.progress = 0;
+            $rootScope.progression = 0;
             $rootScope.total = 360;
 
-            element = $compile('<orbicular progress="progress" total="total"></orbicular>')($rootScope);
+            element = $compile('<orbicular progression="progression" total="total"></orbicular>')($rootScope);
             $rootScope.$digest();
 
             bar = angular.element(
@@ -35,17 +35,17 @@ describe('Orbicular:orbicular (directive)', function() {
 
     it('should link to variables on the parent scope', inject(function($rootScope) {
         // confirm initial state
-        expect($rootScope.progress).toBe(0);
+        expect($rootScope.progression).toBe(0);
         expect($rootScope.total).toBe(360);
         degrees = findDegrees(bar);
         expect(degrees).toBe(0);
 
 
         // Update the progress
-        $rootScope.progress = 10;
+        $rootScope.progression = 10;
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(10);
+        expect($rootScope.progression).toBe(10);
         expect($rootScope.total).toBe(360);
         degrees = findDegrees(bar);
         expect(degrees).toBe(10);
@@ -53,10 +53,10 @@ describe('Orbicular:orbicular (directive)', function() {
 
         // update the total
         $rootScope.total = 300;
-        $rootScope.progress = 11; // progress triggers changes (not total)
+        $rootScope.progression = 11; // progression triggers changes (not total)
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(11);
+        expect($rootScope.progression).toBe(11);
         expect($rootScope.total).toBe(300);
         degrees = findDegrees(bar);
         expect(degrees).toBeGreaterThan(11);    // indicating that the total has changed
@@ -64,41 +64,41 @@ describe('Orbicular:orbicular (directive)', function() {
 
     it('should smoothly animate the transition forward from one side to the other', inject(function($rootScope) {
         // move progress bar past half way
-        $rootScope.progress = 200;
+        $rootScope.progression = 200;
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(200);
+        expect($rootScope.progression).toBe(200);
         degrees = findDegrees(bar);
         expect(degrees).toBe(180);      // stops here to transition the graphic
 
 
-        // the animation end event should move the progress forward
+        // the animation end event should move the progression forward
         bar.trigger('transitionend');
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(200);
+        expect($rootScope.progression).toBe(200);
         degrees = findDegrees(bar);
         expect(degrees).toBe(200);
     }));
 
     it('should transition when stopping at 50% going forward', inject(function($rootScope) {
-        // move progress bar to half way
-        $rootScope.progress = 180;
+        // move progression bar to half way
+        $rootScope.progression = 180;
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(180);
+        expect($rootScope.progression).toBe(180);
         degrees = findDegrees(bar);
         expect(degrees).toBe(180);      // stops here to transition the graphic
 
-        // the animation end event should move the progress forward
+        // the animation end event should move the progression forward
         bar.trigger('transitionend');
         $rootScope.$digest();
 
         // move progress bar past half way
-        $rootScope.progress = 200;
+        $rootScope.progression = 200;
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(200);
+        expect($rootScope.progression).toBe(200);
         degrees = findDegrees(bar);
         expect(degrees).toBe(200);      // stops here to transition the graphic
 
@@ -106,60 +106,60 @@ describe('Orbicular:orbicular (directive)', function() {
         bar.trigger('transitionend');
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(200);
+        expect($rootScope.progression).toBe(200);
         degrees = findDegrees(bar);
         expect(degrees).toBe(200);
     }));
 
     it('should transition when stopping at 50% going backwards', inject(function($rootScope) {
         // move progress bar past half way
-        $rootScope.progress = 200;
+        $rootScope.progression = 200;
         $rootScope.$digest();
 
         bar.trigger('transitionend');
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(200);
+        expect($rootScope.progression).toBe(200);
         degrees = findDegrees(bar);
         expect(degrees).toBe(200);
 
 
         // Move back to 50%
-        $rootScope.progress = 180;
+        $rootScope.progression = 180;
         $rootScope.$digest();
 
         bar.trigger('transitionend');
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(180);
+        expect($rootScope.progression).toBe(180);
         degrees = findDegrees(bar);
         expect(degrees).toBe(180);
 
         // Move backwards
-        $rootScope.progress = 50;
+        $rootScope.progression = 50;
         $rootScope.$digest();
 
         bar.trigger('transitionend');
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(50);
+        expect($rootScope.progression).toBe(50);
         degrees = findDegrees(bar);
         expect(degrees).toBe(50);
     }));
 
     it('should smoothly animate the transition backwards from one side to the other', inject(function($rootScope) {
         // move progress bar past half way
-        $rootScope.progress = 200;
+        $rootScope.progression = 200;
         $rootScope.$digest();
         bar.trigger('transitionend');
         $rootScope.$digest();
 
 
         // move the bar back
-        $rootScope.progress = 100;
+        $rootScope.progression = 100;
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(100);
+        expect($rootScope.progression).toBe(100);
         degrees = findDegrees(bar);
         expect(degrees).toBeGreaterThan(180);      // stops very close to 180
         expect(degrees).toBeLessThan(181);
@@ -169,26 +169,26 @@ describe('Orbicular:orbicular (directive)', function() {
         bar.trigger('transitionend');
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(100);
+        expect($rootScope.progression).toBe(100);
         degrees = findDegrees(bar);
         expect(degrees).toBe(100);
     }));
 
     it('should handle further updates (in the same direction) during a transition phase', inject(function($rootScope) {
         // move progress bar past half way
-        $rootScope.progress = 200;
+        $rootScope.progression = 200;
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(200);
+        expect($rootScope.progression).toBe(200);
         degrees = findDegrees(bar);
         expect(degrees).toBe(180);      // stops here to transition the graphic
 
 
         // update again before the transition end event
-        $rootScope.progress = 300;
+        $rootScope.progression = 300;
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(300);
+        expect($rootScope.progression).toBe(300);
         degrees = findDegrees(bar);
         expect(degrees).toBe(180);
 
@@ -197,25 +197,25 @@ describe('Orbicular:orbicular (directive)', function() {
         bar.trigger('transitionend');
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(300);
+        expect($rootScope.progression).toBe(300);
         degrees = findDegrees(bar);
         expect(degrees).toBe(300);
 
 
         // should work backwards too
-        $rootScope.progress = 100;
+        $rootScope.progression = 100;
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(100);
+        expect($rootScope.progression).toBe(100);
         degrees = findDegrees(bar);
         expect(degrees).toBeGreaterThan(180);      // stops very close to 180
         expect(degrees).toBeLessThan(181);
 
         // update again before the transition end event
-        $rootScope.progress = 0;
+        $rootScope.progression = 0;
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(0);
+        expect($rootScope.progression).toBe(0);
         degrees = findDegrees(bar);
         expect(degrees).toBeGreaterThan(180);      // stops very close to 180
         expect(degrees).toBeLessThan(181);
@@ -224,7 +224,7 @@ describe('Orbicular:orbicular (directive)', function() {
         bar.trigger('transitionend');
         $rootScope.$digest();
 
-        expect($rootScope.progress).toBe(0);
+        expect($rootScope.progression).toBe(0);
         degrees = findDegrees(bar);
         expect(degrees).toBe(0);
     }));


### PR DESCRIPTION
The title sums it up.  Basically if you use UI Bootstrap and are implementing the progress bar. UI Bootstrap tries to bind itself to the progress attribute.
