### PR TITLE
Watch total value for changes in addition to progression

### DIFF
--- a/orbicular.js
+++ b/orbicular.js
@@ -70,7 +70,7 @@
                 restrict: 'EA',
                 scope: {
                     current: '=progression',
-                    total: '='
+                    total: '=total'
                 },
                 link: function (scope, element, attrs) {
                     var circles = [],
@@ -121,6 +121,12 @@
                     // we watch for changes to the progress indicator of the parent scope
                     scope.$watch('current', function (newValue) {
                         newValue = newValue / scope.total * 180.0;
+                        updateProgress(circles, fix, newValue);
+                    });
+                    
+                    // we watch for changes to the total indicator of the parent scope
+                    scope.$watch('total', function (newValue) {
+                        newValue = scope.current / newValue * 180.0;
                         updateProgress(circles, fix, newValue);
                     });
                 }


### PR DESCRIPTION
Right now, only the progression value is observed for changes. For my implementation, I also needed to watch the total value, as both values could change.

I'm not using the project for a file upload progress meter, so this maybe outside of the project's scope, but I thought I'd share.
